### PR TITLE
Remove clean Go mod cache step from workflow

### DIFF
--- a/.github/workflows/status-check.yml
+++ b/.github/workflows/status-check.yml
@@ -9,8 +9,6 @@ jobs:
   check-status:
     runs-on: ubuntu-latest
     steps:
-      - name: Clean Go Mod Cache
-        run: rm -rf $HOME/go/pkg/mod
       - name: Checkout repo
         uses: actions/checkout@v4
       - name: Setup Go


### PR DESCRIPTION
Removed step to clean Go module cache in workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI workflow by removing an unnecessary cache cleanup step, streamlining the build process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->